### PR TITLE
Add interactive Microsoft save folder selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from cogs.AstroSaveContainer import AstroSaveContainer as Container
 from cogs.AstroSave import AstroSave
 from cogs.AstroConvType import AstroConvType
 from cogs.LoadingBar import LoadingBar
-from errors import MultipleFolderFoundError
 
 
 def get_args() -> Namespace:


### PR DESCRIPTION
## Summary
- parse container metadata to collect save names and timestamps
- prompt user to select a save folder when multiple Microsoft save folders are found
- remove unused MultipleFolderFoundError handling
- backup all detected Microsoft save folders and ask user which folder to use for Steam save import
- log user choices for easier debugging

## Testing
- `python -m py_compile cogs/AstroMicrosoftSaveFolder.py AstroSaveScenario.py main.py`
- `python - <<'PY'
import sys, types
sys.modules['winpath'] = types.SimpleNamespace(get_desktop=lambda:'.')
sys.path.insert(0,'AstroSaveConverter')
from cogs.AstroMicrosoftSaveFolder import get_save_details
print(get_save_details('AstroSaveConverter/test_data'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bcd2984a38832b9e760d85880760be