### PR TITLE
Fix double space in save folder prompt

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -69,7 +69,7 @@ def ask_for_save_folder(conversion_type: AstroConvType) -> str:
     """
     while 1:
         try:
-            Logger.logPrint("Which  folder would you like to work with ?")
+            Logger.logPrint("Which folder would you like to work with ?")
             Logger.logPrint("\t1) Automatically detect and copy my save folder (Please close Astroneer first)")
             Logger.logPrint("\t2) Chose a custom folder")
 


### PR DESCRIPTION
## Summary
- remove extra space from save folder selection prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce3fa1a84832b80a29bb23f12040b