### PR TITLE
Label save platform in export prompt

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -153,10 +153,10 @@ def print_save_from_container(save_list):
         Logger.logPrint(f'\t {str(i+1)}) {save.name}')
 
 
-def ask_saves_to_export(save_list: List[AstroSave]) -> List[int]:
+def ask_saves_to_export(save_list: List[AstroSave], platform_label: str) -> List[int]:
     """TODO [doc] explain that this function returns the indexes in the save list and not a sublist of the save_list
     """
-    Logger.logPrint('Extracted save list :')
+    Logger.logPrint(f"{platform_label} saves list :")
     print_save_from_container(save_list)
     Logger.logPrint('\nWhich saves would you like to convert ? (Choose 0 for all of them)')
     Logger.logPrint('(Multi-convert is supported. Ex: "1,2,4")')

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def windows_to_steam_conversion(original_save_path: str) -> None:
 
     Logger.logPrint('Container file loaded successfully !\n')
 
-    saves_to_export = Scenario.ask_saves_to_export(container.save_list)
+    saves_to_export = Scenario.ask_saves_to_export(container.save_list, "Microsoft")
 
     Scenario.ask_rename_saves(saves_to_export, container.save_list)
 
@@ -71,7 +71,7 @@ def steam_to_windows_conversion(original_save_path: str) -> None:
     for save in saves_list:
         original_saves_name.append(save.name)
 
-    saves_indexes_to_export = Scenario.ask_saves_to_export(saves_list)
+    saves_indexes_to_export = Scenario.ask_saves_to_export(saves_list, "Steam")
 
     Scenario.ask_rename_saves(saves_indexes_to_export, saves_list)
 


### PR DESCRIPTION
## Summary
- clarify save selection prompt by adding a platform label
- pass platform labels for Microsoft and Steam conversions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce72aaef0832b9983b1cbcfba3fe1