### PR TITLE
Log export path for Steam save conversion

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -273,10 +273,11 @@ def ask_overwrite_if_file_exists(filename: str, target: str) -> bool:
         return True
 
 
-def export_save_to_steam(save: AstroSave, from_path: str, to_path: str) -> None:
+def export_save_to_steam(save: AstroSave, from_path: str, to_path: str) -> str:
     target_full_path = utils.join_paths(to_path, save.get_file_name())
     converted_save = save.convert_to_steam(from_path)
     utils.write_buffer_to_file(target_full_path, converted_save)
+    return target_full_path
 
 
 def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> None:

--- a/main.py
+++ b/main.py
@@ -51,7 +51,8 @@ def windows_to_steam_conversion(original_save_path: str) -> None:
         save = container.save_list[save_index]
 
         Scenario.ask_overwrite_save_while_file_exists(save, to_path)
-        Scenario.export_save_to_steam(save, original_save_path, to_path)
+        export_path = Scenario.export_save_to_steam(save, original_save_path, to_path)
+        Logger.logPrint(f"Container: {container_url} has been exported to {export_path}", "debug")
 
         Logger.logPrint(f"\nSave {save.name} has been exported succesfully.")
 


### PR DESCRIPTION
## Summary
- return export path from `export_save_to_steam`
- log container and destination path during Windows -> Steam conversion

## Testing
- `python -m py_compile main.py AstroSaveScenario.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcf707620c832b9ee7818c2381e486