### PR TITLE
Log user input choices

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -34,6 +34,7 @@ def ask_user_to_choose_in_a_list(text, file_list):
         Logger.logPrint('\nWhich container would you like to convert ?')
         print_list_elements(file_list)
         choice_index = input()
+        Logger.logPrint(f"User choice: {choice_index}", "debug")
         try:
             choice_index = int(choice_index)
             verify_choice_input(choice_index, min_container_number, max_container_number)
@@ -41,7 +42,6 @@ def ask_user_to_choose_in_a_list(text, file_list):
             choice_index = 0
             Logger.logPrint(f'Please use only values between {min_container_number} and {max_container_number}')
 
-    Logger.logPrint(f"User choice: {choice_index}", "debug")
     return file_list[choice_index-1]
 
 
@@ -74,11 +74,11 @@ def ask_for_save_folder(conversion_type: AstroConvType) -> str:
             Logger.logPrint("\t2) Chose a custom folder")
 
             work_choice = input()
+            Logger.logPrint(f"User choice: {work_choice}", "debug")
             while work_choice not in ('1', '2'):
                 Logger.logPrint(f'\nPlease choose 1 or 2')
                 work_choice = input()
-
-            Logger.logPrint(f"User choice: {work_choice}", "debug")
+                Logger.logPrint(f"User choice: {work_choice}", "debug")
             if work_choice == '1':
                 if conversion_type == AstroConvType.WIN2STEAM:
                     astroneer_save_folder = AstroMicrosoftSaveFolder.get_microsoft_save_folder()
@@ -118,11 +118,11 @@ def ask_copy_target(folder_main_name: str, save_type: str):
     Logger.logPrint("\t2) New folder in a custom path")
 
     choice = input()
+    Logger.logPrint(f"User choice: {choice}", "debug")
     while choice not in ('1', '2'):
         Logger.logPrint(f'\nPlease choose 1 or 2')
         choice = input()
-
-    Logger.logPrint(f"User choice: {choice}", "debug")
+        Logger.logPrint(f"User choice: {choice}", "debug")
 
     if choice == '1':
         # Winpath is needed here because Windows user can have a custom Desktop location
@@ -138,9 +138,9 @@ def ask_copy_target(folder_main_name: str, save_type: str):
 def ask_custom_folder_path() -> str:
     Logger.logPrint(f'\nEnter your custom folder path:')
     path = input()
+    Logger.logPrint(f"User choice: {path}", "debug")
 
     if utils.is_folder_a_dir(path):
-        Logger.logPrint(f"User choice: {path}", "debug")
         return path
     else:
         Logger.logPrint(f'\nWrong path for save folder, please enter a valid path : ')
@@ -185,14 +185,13 @@ def ask_for_multiple_choices(maximum_value) -> list:
     choices = []
     while not choices:
         choices = input()
+        Logger.logPrint(f"User choice: {choices}", "debug")
         try:
             choices = process_multiple_choices_input(choices)
             verify_choices_input(choices, maximum_value)
         except ValueError:
             choices = []
             Logger.logPrint(f'Please use only values between 1 and {maximum_value} or 0 alone')
-
-    Logger.logPrint(f"User choice: {choices}", "debug")
 
     if choices == [-1]:
         return list(range(0, maximum_value))
@@ -230,8 +229,7 @@ def ask_rename_saves(saves_indexes, save_list):
     while do_rename not in ('y', 'n'):
         Logger.logPrint('\nWould you like to rename a save ? (y/n)')
         do_rename = input().lower()
-
-    Logger.logPrint(f"User choice: {do_rename}", "debug")
+        Logger.logPrint(f"User choice: {do_rename}", "debug")
 
     if do_rename == 'y':
         for index in saves_indexes:
@@ -248,14 +246,13 @@ def rename_save(save):
     new_name = None
     while new_name is None:
         new_name = input(f'\nNew name for {save.name.split("$")[0]}: [ENTER = unchanged] > ').upper()
+        Logger.logPrint(f"User choice: {new_name}", "debug")
         if (new_name != ''):
             try:
                 save.rename(new_name)
             except ValueError:
                 new_name = None
                 Logger.logPrint(f'Please use only alphanum and a length < 30')
-
-    Logger.logPrint(f"User choice: {new_name}", "debug")
 
 
 def ask_overwrite_if_file_exists(filename: str, target: str) -> bool:
@@ -266,8 +263,8 @@ def ask_overwrite_if_file_exists(filename: str, target: str) -> bool:
         while do_overwrite not in ('y', 'n'):
             Logger.logPrint(f'\nFile {filename} already exists, overwrite it ? (y/n)')
             do_overwrite = input().lower()
+            Logger.logPrint(f"User choice: {do_overwrite}", "debug")
 
-        Logger.logPrint(f"User choice: {do_overwrite}", "debug")
         return do_overwrite == 'y'
     else:
         return True
@@ -364,11 +361,11 @@ def ask_conversion_type() -> AstroConvType:
     Logger.logPrint('\t2) Convert a Steam save into a Microsoft save')
 
     choice = input()
+    Logger.logPrint(f"User choice: {choice}", "debug")
     while choice not in ('1', '2'):
         Logger.logPrint(f'\nPlease choose 1 or 2')
         choice = input()
-
-    Logger.logPrint(f"User choice: {choice}", "debug")
+        Logger.logPrint(f"User choice: {choice}", "debug")
     if choice == '1':
         return AstroConvType.WIN2STEAM
     else:
@@ -418,10 +415,10 @@ def ask_microsoft_target_folder() -> str:
 
     while True:
         choice = input()
+        Logger.logPrint(f"User choice: {choice}", "debug")
         try:
             choice_int = int(choice)
             if 1 <= choice_int <= len(save_folders):
-                Logger.logPrint(f"User choice: {choice_int}", "debug")
                 return save_folders[choice_int - 1]
         except ValueError:
             pass

--- a/cogs/AstroMicrosoftSaveFolder.py
+++ b/cogs/AstroMicrosoftSaveFolder.py
@@ -59,10 +59,10 @@ def seek_microsoft_save_folder(appdata_path) -> str:
 
     while True:
         choice = input()
+        Logger.logPrint(f"User choice: {choice}", "debug")
         try:
             index = int(choice)
             if 1 <= index <= len(folders):
-                Logger.logPrint(f"User choice: {choice}", "debug")
                 return folders[index - 1]
         except ValueError:
             pass

--- a/tests/test_input_logging.py
+++ b/tests/test_input_logging.py
@@ -1,0 +1,64 @@
+import builtins
+from unittest.mock import patch, call
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import AstroSaveScenario as scenario
+from cogs.AstroConvType import AstroConvType
+from cogs import AstroMicrosoftSaveFolder
+from cogs.AstroSave import AstroSave
+
+
+def _call_args_contains(mock, expected_call):
+    return any(c == expected_call for c in mock.call_args_list)
+
+
+def test_ask_conversion_type_logs_choice():
+    with patch.object(builtins, 'input', side_effect=['1']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        result = scenario.ask_conversion_type()
+        assert result == AstroConvType.WIN2STEAM
+        assert _call_args_contains(log_mock, call('User choice: 1', 'debug'))
+
+
+def test_ask_copy_target_logs_choices():
+    with patch.object(builtins, 'input', side_effect=['2', '/tmp']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        scenario.ask_copy_target('folder', 'Steam')
+        assert _call_args_contains(log_mock, call('User choice: 2', 'debug'))
+        assert _call_args_contains(log_mock, call('User choice: /tmp', 'debug'))
+
+
+def test_ask_for_multiple_choices_logs():
+    with patch.object(builtins, 'input', side_effect=['1,2']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        result = scenario.ask_for_multiple_choices(4)
+        assert result == [0, 1]
+        assert _call_args_contains(log_mock, call('User choice: 1,2', 'debug'))
+
+
+def test_ask_rename_saves_logs():
+    save = AstroSave('OLD$2024.01.01-00.00.00', [])
+    with patch.object(builtins, 'input', side_effect=['n']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        scenario.ask_rename_saves([0], [save])
+        assert _call_args_contains(log_mock, call('User choice: n', 'debug'))
+
+
+def test_rename_save_logs():
+    save = AstroSave('OLD$2024.01.01-00.00.00', [])
+    with patch.object(builtins, 'input', side_effect=['newname']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        scenario.rename_save(save)
+        assert save.name.startswith('NEWNAME$')
+        assert _call_args_contains(log_mock, call('User choice: NEWNAME', 'debug'))
+
+
+def test_seek_microsoft_save_folder_logs_choice():
+    with patch.object(builtins, 'input', side_effect=['1']), \
+         patch('cogs.AstroLogging.logPrint') as log_mock, \
+         patch('cogs.AstroMicrosoftSaveFolder.get_save_folders_from_path', return_value=['a', 'b']):
+        result = AstroMicrosoftSaveFolder.seek_microsoft_save_folder('x')
+        assert result == 'a'
+        assert _call_args_contains(log_mock, call('User choice: 1', 'debug'))


### PR DESCRIPTION
## Summary
- Log every user input immediately across save conversion prompts
- Add tests ensuring interactive functions log selections correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcf918393c832b99c401d90c87ae01