### PR TITLE
feat: insert log separator before exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -151,6 +151,7 @@ if __name__ == "__main__":
             steam_to_windows_conversion(original_save_path)
 
         Logger.logPrint(f'\nTask completed, press any key to exit')
+        Logger.logPrint("\n" + "-" * 60 + "\n")
         utils.wait_and_exit(0)
     except Exception as e:
         Logger.logPrint(e)


### PR DESCRIPTION
## Summary
- print dashed separator line before exit to clearly mark end of log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd009b51c4832b9f31869592fff412