### PR TITLE
Handle missing container path for Windows to Steam conversion

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,15 @@ def windows_to_steam_conversion(original_save_path: str) -> None:
     Raises:
         FileNotFoundError: If no container file is found in ``original_save_path``.
     """
-    containers_list = Container.get_containers_list(original_save_path)
+    try:
+        containers_list = Container.get_containers_list(original_save_path)
+    except FileNotFoundError:
+        Logger.logPrint(
+            "No container found in the selected folder. Please choose another path."
+        )
+        original_save_path = Scenario.ask_for_save_folder(AstroConvType.WIN2STEAM)
+        Logger.logPrint(f"User selected new path: {original_save_path}", "debug")
+        containers_list = Container.get_containers_list(original_save_path)
 
     Logger.logPrint('\nContainers found:' + str(containers_list))
     container_name = Scenario.ask_for_containers_to_convert(


### PR DESCRIPTION
## Summary
- Prompt user to pick new folder if Microsoft save container is missing during Windows-to-Steam conversion
- Log user's re-selection for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd04f6d194832bb098d0cdb3da91b0