### PR TITLE
Add logging for input prompts and extend coverage tests

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -568,6 +568,7 @@ def ask_microsoft_target_folder() -> str:
 
     while True:
         choice = input()
+        Logger.logPrint(f"User choice: {choice}", "debug")
         try:
             choice_int = int(choice)
             if 1 <= choice_int <= len(save_folders):
@@ -576,5 +577,4 @@ def ask_microsoft_target_folder() -> str:
             pass
         Logger.logPrint(f'Please choose a number between 1 and {len(save_folders)}')
 
-    Logger.logPrint(f"User choice: {choice}", "debug")
     return save_folders[choice_int - 1]

--- a/cogs/AstroMicrosoftSaveFolder.py
+++ b/cogs/AstroMicrosoftSaveFolder.py
@@ -72,6 +72,7 @@ def seek_microsoft_save_folder(appdata_path: str) -> str:
 
     while True:
         choice = input()
+        Logger.logPrint(f"User choice: {choice}", "debug")
         try:
             index = int(choice)
             if 1 <= index <= len(folders):
@@ -80,7 +81,6 @@ def seek_microsoft_save_folder(appdata_path: str) -> str:
             pass
         Logger.logPrint('Invalid selection. Please enter a valid number.')
 
-    Logger.logPrint(f"User choice: {choice}", "debug")
     return folders[index - 1]
 
 

--- a/tests/test_input_logging.py
+++ b/tests/test_input_logging.py
@@ -15,7 +15,7 @@ def _call_args_contains(mock, expected_call):
 
 
 def test_ask_conversion_type_logs_choice():
-    with patch.object(builtins, 'input', side_effect=['1']), \
+    with patch.object(builtins, 'input', side_effect=['3', '1']), \
          patch('cogs.AstroLogging.logPrint') as log_mock:
         result = scenario.ask_conversion_type()
         assert result == AstroConvType.WIN2STEAM
@@ -56,9 +56,33 @@ def test_rename_save_logs():
 
 
 def test_seek_microsoft_save_folder_logs_choice():
-    with patch.object(builtins, 'input', side_effect=['1']), \
+    with patch.object(builtins, 'input', side_effect=['3', '1']), \
          patch('cogs.AstroLogging.logPrint') as log_mock, \
          patch('cogs.AstroMicrosoftSaveFolder.get_save_folders_from_path', return_value=['a', 'b']):
         result = AstroMicrosoftSaveFolder.seek_microsoft_save_folder('x')
         assert result == 'a'
+        assert _call_args_contains(log_mock, call('User choice: 3', 'debug'))
         assert _call_args_contains(log_mock, call('User choice: 1', 'debug'))
+
+def test_ask_microsoft_target_folder_logs_choice():
+    with patch.object(builtins, 'input', side_effect=['3', '1']), \
+         patch.dict('os.environ', {'LOCALAPPDATA': '/tmp'}), \
+         patch('glob.iglob', return_value=['dummy']), \
+         patch('cogs.AstroMicrosoftSaveFolder.get_save_folders_from_path', return_value=['a', 'b']), \
+         patch('cogs.AstroMicrosoftSaveFolder.get_save_details', return_value=[]), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        result = scenario.ask_microsoft_target_folder()
+        assert result == 'a'
+        assert _call_args_contains(log_mock, call('User choice: 3', 'debug'))
+        assert _call_args_contains(log_mock, call('User choice: 1', 'debug'))
+
+
+def test_backup_win_before_steam_export_logs_choice():
+    with patch.object(builtins, 'input', side_effect=['4', '3']), \
+         patch('cogs.AstroMicrosoftSaveFolder.find_microsoft_save_folders', side_effect=FileNotFoundError()), \
+         patch('AstroSaveScenario.ask_copy_target', return_value='/tmp'), \
+         patch('cogs.AstroLogging.logPrint') as log_mock:
+        result = scenario.backup_win_before_steam_export()
+        assert result == ''
+        assert _call_args_contains(log_mock, call('User choice: 4', 'debug'))
+        assert _call_args_contains(log_mock, call('User choice: 3', 'debug'))


### PR DESCRIPTION
## Summary
- log user input for Microsoft folder selection
- log choices when multiple Microsoft save folders exist
- test logging for Microsoft target selection and backup options

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68bd055a7fe4832b867896e31355cf0d