### PR TITLE
Ensure Xbox export initializes missing container

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -392,6 +392,8 @@ def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> None:
 
     chunk_count = len(chunk_uuids)
 
+    utils.make_dir_if_doesnt_exists(to_path)
+
     if chunk_count >= 10:
         Logger.logPrint(
             f'The selected save contains {chunk_count} which is over the 9 chunks limit AstroSaveconverter can handle yet')
@@ -420,7 +422,11 @@ def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> None:
         utils.write_buffer_to_file(target_full_path, converted_chunks[i])
 
     # Container is updated only after all the chunks of the save have been written successfully
-    container_file_name = Container.get_containers_list(to_path)[0]
+    try:
+        container_file_name = Container.get_containers_list(to_path)[0]
+    except FileNotFoundError:
+        Container.create_empty_container(to_path)
+        container_file_name = 'container.1'
 
     container_full_path = utils.join_paths(to_path, container_file_name)
 

--- a/cogs/AstroSaveContainer.py
+++ b/cogs/AstroSaveContainer.py
@@ -168,6 +168,17 @@ class AstroSaveContainer:
         return containers_list
 
     @staticmethod
+    def create_empty_container(path: str) -> None:
+        """Create an empty container file in ``path``.
+
+        Args:
+            path: Directory where the blank container should be created.
+        """
+        container_full_path = join_paths(path, 'container.1')
+        with open(container_full_path, 'wb') as container:
+            container.write(b'\x04\x00\x00\x00\x00\x00\x00\x00')
+
+    @staticmethod
     def is_a_container_file(path) -> bool:
         """Return ``True`` if ``path`` looks like a save container.
 


### PR DESCRIPTION
## Summary
- Ensure export_save_to_xbox creates destination directory and handles missing container
- Add utility to create an empty save container file with zero chunks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd0b6c1ea4832bbdf6f2419d44d0c5