### PR TITLE
Handle missing Microsoft saves during Steam export

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -489,13 +489,11 @@ def ask_conversion_type() -> AstroConvType:
 
 
 def backup_win_before_steam_export() -> str:
-    """Backup existing Microsoft saves before exporting from Steam.
+    """Prepare Microsoft save folders before exporting from Steam.
 
     Returns:
-        str: Path to the first detected Microsoft save folder.
-
-    Raises:
-        FileNotFoundError: If no Microsoft save folders are discovered.
+        str: Path to a Microsoft save folder to export to, or the directory
+        chosen by the user when no Microsoft save folders are detected.
     """
     Logger.logPrint('\nFor safety reasons, we will now copy your current Microsoft Astroneer saves')
     try:
@@ -514,9 +512,13 @@ def backup_win_before_steam_export() -> str:
         if choice == '3':
             Logger.logPrint('Launch the Microsoft version of Astroneer once, then relaunch AstroSaveConverter.')
             return ''
-        backup_path = ask_copy_target('MicrosoftAstroneerSavesBackup', 'Microsoft')
-        utils.make_dir_if_doesnt_exists(backup_path)
-        return backup_path
+        if choice == '1':
+            base_path = utils.get_windows_desktop_path()
+        else:
+            base_path = ask_custom_folder_path()
+        output_path = utils.join_paths(base_path, utils.create_folder_name('MicrosoftAstroneerSavesBackup'))
+        utils.make_dir_if_doesnt_exists(output_path)
+        return output_path
     Logger.logPrint(f"{len(folders)} different Microsoft save folders have been detected. They will all be backed up.")
     backup_path = ask_copy_target('MicrosoftAstroneerSavesBackup', 'Microsoft')
     AstroMicrosoftSaveFolder.backup_microsoft_save_folders(folders, backup_path)

--- a/tests/test_input_logging.py
+++ b/tests/test_input_logging.py
@@ -80,7 +80,6 @@ def test_ask_microsoft_target_folder_logs_choice():
 def test_backup_win_before_steam_export_logs_choice():
     with patch.object(builtins, 'input', side_effect=['4', '3']), \
          patch('cogs.AstroMicrosoftSaveFolder.find_microsoft_save_folders', side_effect=FileNotFoundError()), \
-         patch('AstroSaveScenario.ask_copy_target', return_value='/tmp'), \
          patch('cogs.AstroLogging.logPrint') as log_mock:
         result = scenario.backup_win_before_steam_export()
         assert result == ''


### PR DESCRIPTION
## Summary
- Skip backup prompt when no Microsoft save folders are detected and ask for a destination for converted saves instead
- Use the chosen location as the export directory
- Adjust logging test for new workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd0e35ed04832b88f5d052edb18078