### PR TITLE
Handle invalid custom folder paths without stack trace

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -191,8 +191,8 @@ def ask_custom_folder_path() -> str:
         if not os.path.isdir(path):
             try:
                 os.makedirs(path)
-            except OSError as e:
-                Logger.logPrint(e, 'exception')
+            except OSError:
+                Logger.logPrint('Path cannot be created or drive not found.', 'error')
                 Logger.logPrint('\nWrong path for save folder, please enter a valid path : ', 'error')
                 continue
 


### PR DESCRIPTION
## Summary
- Replace exception stack trace with a user-friendly error message when custom folder creation fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd128069ec832bb95ca1c82c245c76