### PR TITLE
Log export path after save conversion

### DIFF
--- a/AstroSaveScenario.py
+++ b/AstroSaveScenario.py
@@ -389,13 +389,16 @@ def export_save_to_steam(save: AstroSave, from_path: str, to_path: str) -> str:
     return target_full_path
 
 
-def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> None:
+def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> str:
     """Export a Steam save into multiple Xbox chunk files.
 
     Args:
         save: ``AstroSave`` instance to convert.
         from_file: Path to the Steam ``.savegame`` file.
         to_path: Destination directory for the Xbox chunks.
+
+    Returns:
+        str: Directory where the chunks and container are written.
 
     Raises:
         FileExistsError: If generated chunk names already exist and cannot be
@@ -474,6 +477,8 @@ def export_save_to_xbox(save: AstroSave, from_file: str, to_path: str) -> None:
 
     Logger.logPrint(f'Editing container: {container_full_path}', "debug")
     utils.append_buffer_to_file(container_full_path, chunks_buffer)
+
+    return to_path
 
 
 def ask_overwrite_save_while_file_exists(save: AstroSave, target: str) -> None:

--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def windows_to_steam_conversion(original_save_path: str) -> None:
         export_path = Scenario.export_save_to_steam(save, original_save_path, to_path)
         Logger.logPrint(f"Container: {container_url} has been exported to {export_path}", "debug")
 
-        Logger.logPrint(f"\nSave {save.name} has been exported succesfully.")
+        Logger.logPrint(f"\nSave {save.name} has been exported successfully to {export_path}")
 
 
 def steam_to_windows_conversion(original_save_path: str) -> None:
@@ -123,9 +123,9 @@ def steam_to_windows_conversion(original_save_path: str) -> None:
     for save_index in saves_indexes_to_export:
         save = saves_list[save_index]
         original_save_full_path = utils.join_paths(original_save_path, original_saves_name[save_index]+'.savegame')
-        Scenario.export_save_to_xbox(save, original_save_full_path, microsoft_target_folder)
+        export_path = Scenario.export_save_to_xbox(save, original_save_full_path, microsoft_target_folder)
 
-        Logger.logPrint(f"\nSave {save.name} has been exported succesfully.")
+        Logger.logPrint(f"\nSave {save.name} has been exported successfully to {export_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Include export path in success logs for both conversion directions
- Return destination directory from `export_save_to_xbox`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd1518dd20832bbd9e0868049a0038