### PR TITLE
Add simple GUI front-end for save conversion

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -1,0 +1,58 @@
+import os
+import PySimpleGUI as sg
+
+from main import windows_to_steam_conversion, steam_to_windows_conversion
+from cogs import AstroLogging as Logger
+
+
+def _select_folder_and_convert(conversion_func):
+    """Ask the user for a folder then run the given conversion function."""
+    layout = [
+        [sg.Text("Sélectionnez le dossier de sauvegarde")],
+        [sg.Input(key="-PATH-"), sg.FolderBrowse("Parcourir")],
+        [sg.Button("Convertir", key="GO"), sg.Button("Annuler")],
+    ]
+    window = sg.Window("Choix du dossier", layout, finalize=True)
+    while True:
+        event, values = window.read()
+        if event in (sg.WINDOW_CLOSED, "Annuler"):
+            break
+        if event == "GO":
+            path = values.get("-PATH-")
+            if not path:
+                sg.popup("Veuillez sélectionner un dossier", keep_on_top=True)
+                continue
+            window.close()
+            conversion_func(path)
+            sg.popup("Conversion terminée !", keep_on_top=True)
+            return
+    window.close()
+
+
+def main():
+    """Launch the AstroSaveConverter GUI."""
+    sg.theme("SystemDefault")
+    sg.set_options(font=("Segoe UI", 12), button_color=("white", "#0078D7"), border_width=0)
+
+    layout = [
+        [sg.Text("AstroSaveConverter", font=("Segoe UI", 16))],
+        [sg.Button("Steam \u2794 Microsoft", key="STEAM2WIN", size=(20, 2))],
+        [sg.Button("Microsoft \u2794 Steam", key="WIN2STEAM", size=(20, 2))],
+    ]
+
+    Logger.setup_logging(os.getcwd())
+
+    window = sg.Window("AstroSaveConverter", layout, element_justification="center")
+    while True:
+        event, _ = window.read()
+        if event == sg.WINDOW_CLOSED:
+            break
+        if event == "STEAM2WIN":
+            _select_folder_and_convert(steam_to_windows_conversion)
+        elif event == "WIN2STEAM":
+            _select_folder_and_convert(windows_to_steam_conversion)
+    window.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 hexdump==3.3
 PyInstaller==3.6
 winpath==202002.2
+PySimpleGUI==4.60.5


### PR DESCRIPTION
## Summary
- introduce `gui/app.py` providing a flat PySimpleGUI window with buttons for Steam ➜ Microsoft and Microsoft ➜ Steam conversions
- call existing `steam_to_windows_conversion` and `windows_to_steam_conversion` functions based on user choice
- document PySimpleGUI dependency in `requirements.txt`

## Testing
- `python -m py_compile gui/app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies PySimpleGUI due to proxy restrictions)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd188927f0832b930892082b549273