### PR TITLE
chore: bump PySimpleGUI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hexdump==3.3
 PyInstaller==3.6
 winpath==202002.2
-PySimpleGUI==4.60.5
+PySimpleGUI>=5.0.8,<5.1


### PR DESCRIPTION
## Summary
- update PySimpleGUI requirement to allow version 5.x

## Testing
- `pytest -q`
- `python gui/app.py` *(fails: ModuleNotFoundError: No module named 'PySimpleGUI')*


------
https://chatgpt.com/codex/tasks/task_e_68bd1de64a44832bab02d0050d371bcb