### PR TITLE
Add API docs page and configure Sphinx RTD theme

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,38 @@
+API Reference
+=============
+
+.. automodule:: main
+   :members:
+   :undoc-members:
+
+.. automodule:: utils
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroLogging
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroSaveContainer
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroSave
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroSteamSaveFolder
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroMicrosoftSaveFolder
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.AstroConvType
+   :members:
+   :undoc-members:
+
+.. automodule:: cogs.LoadingBar
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,13 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 project = 'AstroSaveConverter'
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosummary',
+]
 templates_path = ['_templates']
 exclude_patterns = []
 
-html_theme = 'alabaster'
+autosummary_generate = True
+html_theme = 'sphinx_rtd_theme'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,3 +5,12 @@ Welcome to AstroSaveConverter's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+


### PR DESCRIPTION
## Summary
- switch the Sphinx documentation to the Read the Docs theme and enable autosummary generation
- add an API reference page that documents the main modules in the project
- expose the new API page in the documentation table of contents

## Testing
- sphinx-build -b html docs docs/_build/html *(fails: sphinx-build command not available and installation is blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d954fd939c832ba009a13f5efbc22e