### PR TITLE
Separate documentation dependencies from runtime requirements

### DIFF
--- a/BuildEXE.py
+++ b/BuildEXE.py
@@ -4,12 +4,14 @@ import PyInstaller.__main__
 import os
 import shutil
 
+data_sep = ';' if os.name == 'nt' else ':'
+
 args = [
     '--name=AstroSaveConverter',
     '--onefile',
     '--clean',
     '--noconfirm',
-    '--add-data=assets/*;.',
+    f'--add-data=assets/*{data_sep}.',
     '--icon=assets/astroconverterlogo.ico',
     '--exclude-module=sphinx',
     '--exclude-module=sphinx_rtd_theme',

--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ This software is distributed under the [GNU GPLv3](https://choosealicense.com/li
 
 ## Generating the .exe (Windows + Git Bash)
 
-- From the project root (where main.py is located), run:
+- From the project root (where `main.py` is located), install the runtime
+  dependencies required by the converter and build pipeline:
 ``` bash
-pip install --upgrade pyinstaller
+pip install -r requirements.txt
 ```
+- Once the dependencies are installed, run PyInstaller via the helper script:
 ``` bash
 .venv/Scripts/python.exe BuildEXE.py
 ```
@@ -142,9 +144,13 @@ pip install --upgrade pyinstaller
 To build the project documentation locally:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-docs.txt
 sphinx-build -b html docs/ build/html
 ```
+
+The documentation dependencies are kept separate from the runtime
+requirements. Install them only when you need to work on or build the
+documentation locally.
 
 # Special thanks
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+# Documentation build dependencies
+sphinx>=8.2.3
+sphinx-rtd-theme>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
+# Runtime and build dependencies for AstroSaveConverter.
 hexdump==3.3
 PyInstaller==6.16.0
 winpath==202002.2
 setuptools>=78.1.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-# Documentation dependencies
-sphinx>=8.2.3
-sphinx-rtd-theme>=1.3.0
 requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+
+# Documentation dependencies are listed in requirements-docs.txt


### PR DESCRIPTION
## Summary
- move Sphinx documentation dependencies into a dedicated requirements-docs.txt file
- update README build instructions to install runtime dependencies separately from documentation requirements
- adjust BuildEXE.py to handle platform-specific PyInstaller data separator syntax

## Testing
- python BuildEXE.py

------
https://chatgpt.com/codex/tasks/task_e_68e9937bc79c832ba530b9767374ed7f